### PR TITLE
fix: Access store host.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN mkdir -p /var/www/ && \
 		-L "$URL_REPO/$BASE_VERSION.zip" && \
 	unzip -o $BINARY_NAME.zip && \
 	mv $BINARY_NAME $REPO_NAME && \
-	rm $BINARY_NAME.zip && \
 	cd $REPO_NAME && \
 	cp -rf ./packages/default-vsf ./src/modules && \
 	cp ./docker/proxy-api/proxy-api.sh /usr/local/bin/ && \
@@ -57,7 +56,9 @@ RUN mkdir -p /var/www/ && \
 	cp graphql-schema-linter.config.js /var/www/  && \
 	cp tsconfig.build.json /var/www/  && \
 	yarn install --no-cache && \
+	# delete unised files
 	apk del .build-deps && \
+	rm /var/www/$BINARY_NAME.zip && \
 	rm -rf /var/cache/apk/* \
 		/var/lib/apt/list/* \
 		/tmp/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Proxy ADempiere-API
 ### What is?
 A simple proxy for synchronize ADempiere Backend based on [ADempiere-gRPC-Server](https://github.com/adempiere/adempiere-gRPC-Server) with any frontend using api REST ans GraphQL.
 
+Source repository [Proxy-ADempiere-API](https://github.com/adempiere/proxy-adempiere-api).
 
 ### For all enviroment you should run the follow images:
 - ADempiere gRPC: https://hub.docker.com/r/erpya/adempiere-grpc-all-in-one
@@ -55,7 +56,6 @@ docker run -it -d \
 ## Environment variables for the configuration
 
 * **`VS_ENV`**: Indicates the startup mode in which the RESTful proxy service will start, by default its value is `prod`, the other value is `dev`.
-* **`SERVER_HOST`**: Indicates the port in which the RESTful proxy service will be initiated, by default its value is `localhost`. Make sure that it is set to the same value as the TCP port of the container.
 * **`SERVER_PORT`**: Indicates the listening port of the RESTful proxy service, by default its value is `8085`. Make sure that it is set to the same value as the TCP port of the container.
 * **`AD_DEFAULT_HOST`**: Specifies the host to point to the gRPC service, by default its value is `localhost`. All hosts pointing to gRPC services will take the value you set for this environment variable unless you set a value to overwrite the specific service.
 * **`AD_DEFAULT_PORT`**: Specifies the listening port to point to the gRPC service, by default its value is `50059`. All ports to be pointed to from gRPC services will take the value you set for this environment variable unless you set a value to overwrite the specific service.
@@ -65,10 +65,10 @@ docker run -it -d \
 * **`AD_BUSINESS_PORT`**: If not set it takes the value of `AD_DEFAULT_PORT`, it is used to indicate the port for the adempiere business data grpc service.
 * **`AD_DICTIONARY_HOST`**: If not set it takes the value of `AD_DEFAULT_HOST`, it is used to indicate the host for the adempiere dictionary grpc service.
 * **`AD_DICTIONARY_PORT`**: If not set it takes the value of `AD_DEFAULT_PORT`, it is used to indicate the port for the adempiere dictionary grpc service.
-* **`AD_STORE_ACCESS_HOST`**: If not set it takes the value of `AD_DEFAULT_HOST`, it is used to indicate the host for the adempiere access store grpc service.
-* **`AD_STORE_ACCESS_PORT`**: If not set it takes the value of `AD_DEFAULT_PORT`, it is used to indicate the port for the adempiere access store grpc service.
 * **`AD_STORE_HOST`**: If not set it takes the value of `AD_DEFAULT_HOST`, it is used to indicate the host for the adempiere store data grpc service.
 * **`AD_STORE_PORT`**: If not set it takes the value of `AD_DEFAULT_PORT`, it is used to indicate the port for the adempiere store data grpc service.
+* **`AD_STORE_ACCESS_HOST`**: It is used to indicate the host for the adempiere access store grpc service. If not set it takes the value of `AD_STORE_HOST` (and if that is not defined then it takes the value of `AD_DEFAULT_HOST`).
+* **`AD_STORE_ACCESS_PORT`**: It is used to indicate the port for the adempiere access store grpc service. If not set it takes the value of `AD_STORE_PORT` (and if that is not defined then it takes the value of `AD_DEFAULT_PORT`).
 * **`ES_HOST`**: Indicates the host to point to where the elastic search service is, by default its value is `localhost`.
 * **`ES_PORT`**: Indicates the listening port of the elastic search service to be pointed to, by default its value is `9200`.
 * **`API_URL_IMAGES`**: By default its value is `localhost`.

--- a/start.sh
+++ b/start.sh
@@ -8,12 +8,10 @@ sed -i "s|SERVER_PORT|$SERVER_PORT|g"  /var/www/proxy-adempiere-api/config/defau
 
 
 # Set env values to grpc access service
-if [ -z "$AD_ACCESS_HOST" ]
-then
+if [ -z "$AD_ACCESS_HOST" ]; then
     AD_ACCESS_HOST=$AD_DEFAULT_HOST
 fi
-if [ -z "$AD_ACCESS_PORT" ]
-then
+if [ -z "$AD_ACCESS_PORT" ]; then
     AD_ACCESS_PORT=$AD_DEFAULT_PORT
 fi
 sed -i "s|AD_ACCESS_HOST|$AD_ACCESS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
@@ -21,12 +19,10 @@ sed -i "s|AD_ACCESS_PORT|$AD_ACCESS_PORT|g"  /var/www/proxy-adempiere-api/config
 
 
 # Set env values to grpc business data service
-if [ -z "$AD_BUSINESS_HOST" ]
-then
+if [ -z "$AD_BUSINESS_HOST" ]; then
     AD_BUSINESS_HOST=$AD_DEFAULT_HOST
 fi
-if [ -z "$AD_BUSINESS_PORT" ]
-then
+if [ -z "$AD_BUSINESS_PORT" ]; then
     AD_BUSINESS_PORT=$AD_DEFAULT_PORT
 fi
 sed -i "s|AD_BUSINESS_HOST|$AD_BUSINESS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
@@ -34,42 +30,35 @@ sed -i "s|AD_BUSINESS_PORT|$AD_BUSINESS_PORT|g"  /var/www/proxy-adempiere-api/co
 
 
 # Set env values to grpc dictionary service
-if [ -z "$AD_DICTIONARY_HOST" ]
-then
+if [ -z "$AD_DICTIONARY_HOST" ]; then
     AD_DICTIONARY_HOST=$AD_DEFAULT_HOST
 fi
-if [ -z "$AD_DICTIONARY_PORT" ]
-then
+if [ -z "$AD_DICTIONARY_PORT" ]; then
     AD_DICTIONARY_PORT=$AD_DEFAULT_PORT
 fi
 sed -i "s|AD_DICTIONARY_HOST|$AD_DICTIONARY_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
 sed -i "s|AD_DICTIONARY_PORT|$AD_DICTIONARY_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
 
 
-# Set env values to grpc access store service
-if [ -z "$AD_STORE_ACCESS_HOST" ]
-then
-    AD_STORE_ACCESS_HOST=$AD_DEFAULT_HOST
-fi
-if [ -z "$AD_STORE_ACCESS_PORT" ]
-then
-    AD_STORE_ACCESS_PORT=$AD_DEFAULT_PORT
-fi
-sed -i "s|AD_STORE_ACCESS_HOST|$AD_STORE_ACCESS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
-sed -i "s|AD_STORE_ACCESS_PORT|$AD_STORE_ACCESS_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
-
-
 # Set env values to grpc store service
-if [ -z "$AD_STORE_HOST" ]
-then
-    AD_STORE_ACCESS_HOST=$AD_DEFAULT_HOST
+if [ -z "$AD_STORE_HOST" ]; then
+    AD_STORE_HOST=$AD_DEFAULT_HOST
 fi
-if [ -z "$AD_STORE_PORT" ]
-then
+if [ -z "$AD_STORE_PORT" ]; then
     AD_STORE_PORT=$AD_DEFAULT_PORT
 fi
 sed -i "s|AD_STORE_HOST|$AD_STORE_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
 sed -i "s|AD_STORE_PORT|$AD_STORE_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
+
+# Set env values to grpc access store service
+if [ -z "$AD_STORE_ACCESS_HOST" ]; then
+    AD_STORE_ACCESS_HOST=$AD_STORE_HOST
+fi
+if [ -z "$AD_STORE_ACCESS_PORT" ]; then
+    AD_STORE_ACCESS_PORT=$AD_STORE_PORT
+fi
+sed -i "s|AD_STORE_ACCESS_HOST|$AD_STORE_ACCESS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
+sed -i "s|AD_STORE_ACCESS_PORT|$AD_STORE_ACCESS_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
 
 
 sed -i "s|adempiere_token|$AD_TOKEN|g"  /var/www/proxy-adempiere-api/config/default.json
@@ -87,6 +76,7 @@ sed -i "s|ES_HOST|$ES_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
 sed -i "s|ES_PORT|$ES_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
 
 cd /var/www/proxy-adempiere-api
+
 if [ "$RESTORE_DB" = 'Y' ]; then
   yarn restore7
 fi


### PR DESCRIPTION
The values of the host `AD_STORE_HOST` and the port `AD_STORE_PORT` were not defined correctly.

![Captura de pantalla de 2021-02-28 12-54-32](https://user-images.githubusercontent.com/20288327/109427613-84e63980-79c9-11eb-89b1-25a559870863.png)


In the `AD_STORE_ACCESS_HOST` and `AD_STORE_ACCESS_PORT`, if they are not defined they should take the values of `AD_STORE_HOST` and `AD_STORE_PORT` respectively.

In case `AD_STORE_HOST` and `AD_STORE_PORT` are not defined the values of `AD_DEFAULT_HOST` and `AD_DEFAULT_PORT` will be taken respectively.

