### PR TITLE
fix: uncaughtException Redis connection to localhost:6379 failed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10-alpine3.11
 LABEL maintainer="EdwinBetanc0urt@outlook.com" \
 	description="Proxy ADempiere API RESTful"
 
-# Add system dependencies
+# Add operative system dependencies
 RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
 	rm -rf /var/cache/apk/* && \
 	apk update && \
@@ -28,6 +28,9 @@ ENV VS_ENV=prod \
 	SERVER_PORT=8085 \
 	ES_HOST="localhost" \
 	ES_PORT=9200 \
+	REDIS_HOST="localhost" \
+	REDIS_PORT=6379 \
+	REDIS_DB=0 \
 	AD_DEFAULT_HOST="localhost" \
 	AD_DEFAULT_PORT=50059 \
 	AD_TOKEN="adempiere_token" \

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ curl --location --request POST 'http://Your_gRPC_Server_IP:8085/adempiere-api/us
 Result
 ```shell
 {
-	"code":200,"
-	result":"012c44b6-3ee2-47bd-844e-b1517d405e53"
+	"code":200,
+	"result":"012c44b6-3ee2-47bd-844e-b1517d405e53"
 }
 ```
 
@@ -89,8 +89,8 @@ curl --location --request POST 'https://api.erpya.com/adempiere-api/user/login' 
 Result
 ```shell
 {
-	"code":200,"
-	result":"c7fcf550-ba93-4a02-968b-3a1712acabec"
+	"code":200,
+	"result":"c7fcf550-ba93-4a02-968b-3a1712acabec"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Source repository [Proxy-ADempiere-API](https://github.com/adempiere/proxy-ademp
 ```shell
 docker pull erpya/adempiere-grpc-all-in-one
 ```
+
 - Proxy ADempiere API: https://hub.docker.com/r/erpya/proxy-adempiere-api
 ```shell
 docker pull erpya/proxy-adempiere-api
 ```
+
 - ADempiere Vue: https://hub.docker.com/r/erpya/adempiere-vue
 ```shell
 docker pull erpya/adempiere-vue
@@ -64,6 +66,7 @@ curl --location --request POST 'http://Your_gRPC_Server_IP:8085/adempiere-api/us
     "password": "GardenAdmin"
 }'
 ```
+
 Result
 ```shell
 {
@@ -82,6 +85,7 @@ curl --location --request POST 'https://api.erpya.com/adempiere-api/user/login' 
     "password": "demo"
 }'
 ```
+
 Result
 ```shell
 {
@@ -89,6 +93,7 @@ Result
 	result":"c7fcf550-ba93-4a02-968b-3a1712acabec"
 }
 ```
+
 ## Environment variables for the configuration
 
 * **`VS_ENV`**: Indicates the startup mode in which the RESTful proxy service will start, by default its value is `prod`, the other value is `dev`.
@@ -106,6 +111,10 @@ Result
 * **`AD_STORE_ACCESS_PORT`**: It is used to indicate the port for the adempiere access store grpc service. If not set it takes the value of `AD_STORE_PORT` (and if that is not defined then it takes the value of `AD_DEFAULT_PORT`).
 * **`ES_HOST`**: Indicates the host to point to where the elastic search service is, by default its value is `localhost`.
 * **`ES_PORT`**: Indicates the listening port of the elastic search service to be pointed to, by default its value is `9200`.
+* **`INDEX`**: Eslastic Search index (is like a ‘database’ in a relational database).
+* **`REDIS_HOST`**: Indicates the host to point to where the redis service is, by default its value is `localhost`.
+* **`REDIS_PORT`**: Indicates the listening port of the redis service to be pointed to, by default its value is `6379`.
+* **`REDIS_DB`**: Indicates the data base to be pointed to, by default its value is `0`.
 * **`API_URL_IMAGES`**: By default its value is `localhost`.
 * **`API_HTTP_BASED`**: By default its value is `false`.
 * **`STORE_URL_IMAGES`**: By default its value is `localhost`.

--- a/default.json
+++ b/default.json
@@ -116,9 +116,9 @@
     }
   },
   "redis": {
-    "host": "localhost",
-    "port": 6379,
-    "db": 0,
+    "host": "REDIS_HOST",
+    "port": "REDIS_PORT",
+    "db": "REDIS_DB",
     "auth": false
   },
   "kue": {},
@@ -161,7 +161,7 @@
       "name": "German Store",
       "url": "/de",
       "elasticsearch": {
-        "host": "localhost:8080/api/catalog",
+        "host": "SERVER_HOST:SERVER_PORT/api/catalog",
         "index": "vue_storefront_catalog_de"
       },
       "msi": {
@@ -196,7 +196,7 @@
       "name": "Italian Store",
       "url": "/it",
       "elasticsearch": {
-        "host": "localhost:8080/api/catalog",
+        "host": "SERVER_HOST:SERVER_PORT/api/catalog",
         "index": "vue_storefront_catalog_it"
       },
       "msi": {

--- a/start.sh
+++ b/start.sh
@@ -71,11 +71,16 @@ sed -i "s|STORE_URL_IMAGES|$STORE_URL_IMAGES|g"  /var/www/proxy-adempiere-api/co
 sed -i "s|\"STORE_HTTP_BASED\"|$STORE_HTTP_BASED|g"  /var/www/proxy-adempiere-api/config/default.json
 
 
+# Set env values to redis service
+sed -i "s|REDIS_HOST|$REDIS_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
+sed -i "s|REDIS_PORT|$REDIS_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
+sed -i "s|REDIS_DB|$REDIS_DB|g"  /var/www/proxy-adempiere-api/config/default.json
+
+
 # Set env elastic search values
 sed -i "s|ES_HOST|$ES_HOST|g"  /var/www/proxy-adempiere-api/config/default.json
 sed -i "s|ES_PORT|$ES_PORT|g"  /var/www/proxy-adempiere-api/config/default.json
-
-# Set indices value
+# Set elastic search indices value
 sed -i "s|vue_storefront_catalog|$INDEX|g"  /var/www/proxy-adempiere-api/config/default.json
 
 cd /var/www/proxy-adempiere-api


### PR DESCRIPTION
Added configuration to point to the Redis server, fixing the error:

`
error: uncaughtException: Redis connection to localhost:6379 failed - connect ECONNREFUSED 127.0.0.1:6379 date=Sun Mar 21 2021 22:41:37 GMT+0000 (Coordinated Universal Time), pid=84, uid=0, gid=0, cwd=/var/www/proxy-adempiere-api, execPath=/usr/local/bin/node, version=v10.24.0, argv=[/var/www/proxy-adempiere-api/node_modules/.bin/ts-node, /var/www/proxy-adempiere-api/src], rss=417435648, heapTotal=371638272, heapUsed=337662376, external=250377, loadavg=[0.7734375, 0.6455078125, 0.8056640625], uptime=23557, trace=[column=14, file=net.js, function=TCPConnectWrap.afterConnect [as oncomplete], line=1107, method=afterConnect [as oncomplete], native=false], stack=[Error: Redis connection to localhost:6379 failed - connect ECONNREFUSED 127.0.0.1:6379,     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)]
`

https://github.com/adempiere/proxy-adempiere-api-docker/issues/17