### PR TITLE
Remove unused dns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="EdwinBetanc0urt@outlook.com" \
 	description="Proxy ADempiere API RESTful"
 
 # Add operative system dependencies
-RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
-	rm -rf /var/cache/apk/* && \
+RUN echo rm -rf /var/cache/apk/* && \
 	apk update && \
 	apk upgrade musl && \
 	apk add \


### PR DESCRIPTION
Currently when it's building shows the next error:

````
#6 [2/6] RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && rm -rf /var/c...
#6 0.815 /bin/sh: can't create /etc/resolv.conf: Read-only file system
#6 ERROR: executor failed running [/bin/sh -c echo "nameserver 8.8.8.8" > /etc/resolv.conf && rm -rf /var/cache/apk/* && apk update && apk upgrade musl && apk add --virtual .build-deps curl git python make g++ ca-certificates wget]: runc did not terminate sucessfully
------
> [2/6] RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && rm -rf /var/cache/apk/* && apk update && apk upgrade musl && apk add --virtual .build-deps curl git python make g++ ca-certificates wget:
------
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c echo "nameserver 8.8.8.8" > /etc/resolv.conf && rm -rf /var/cache/apk/* && apk update && apk upgrade musl && apk add --virtual .build-deps curl git python make g++ ca-certificates wget]: runc did not terminate sucessfully
Build failed using Buildkit
````